### PR TITLE
kafka-to-tsdb template

### DIFF
--- a/kafka-to-tsdb/function.yaml.template
+++ b/kafka-to-tsdb/function.yaml.template
@@ -1,0 +1,21 @@
+metadata:
+  name: kafka-to-tsdb
+spec:
+  build:
+    functionSourceCode: {{ .SourceCode }}
+  description: "Listens on given kafka topics and ingests given events to TSDB"
+  handler: "main:handler"
+  runtime: "python:3.6"
+  minReplicas: 1
+  maxReplicas: 1
+  triggers:
+    kafkaTrigger:
+      kind: kafka-cluster
+      workerAllocatorName: {{ .workerAllocatorName }}
+      attributes:
+        consumerGroup: {{ .consumerGroup }}
+        initialOffset: {{ .initialOffset }}
+        topics: 
+        - {{ .topic }}
+        brokers:
+        - {{ .broker }}

--- a/kafka-to-tsdb/function.yaml.template
+++ b/kafka-to-tsdb/function.yaml.template
@@ -7,8 +7,8 @@ spec:
   handler: "main:handler"
   runtime: "python:3.6"
   env:
-  - name: INJEST_FUNCTION
-    value: {{ .InjestFunction }}
+  - name: INGEST_FUNCTION
+    value: {{ .IngestFunction }}
   minReplicas: 1
   maxReplicas: 1
   triggers:

--- a/kafka-to-tsdb/function.yaml.template
+++ b/kafka-to-tsdb/function.yaml.template
@@ -6,16 +6,18 @@ spec:
   description: "Listens on given kafka topics and ingests given events to TSDB"
   handler: "main:handler"
   runtime: "python:3.6"
+  env:
+  - name: INJEST_FUNCTION
+    value: {{ .InjestFunction }}
   minReplicas: 1
   maxReplicas: 1
   triggers:
     kafkaTrigger:
       kind: kafka-cluster
-      workerAllocatorName: {{ .workerAllocatorName }}
       attributes:
-        consumerGroup: {{ .consumerGroup }}
-        initialOffset: {{ .initialOffset }}
+        consumerGroup: {{ .ConsumerGroup }}
+        initialOffset: {{ .InitialOffset }}
         topics: 
-        - {{ .topic }}
+        - {{ .Topic }}
         brokers:
-        - {{ .broker }}
+        - {{ .Broker }}

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -26,9 +26,9 @@ Broker:
   required: true
 
 InjestFunction:
-  displayName: InjestFunction
+  displayName: Injest Function (e.g. default-tenant-tsdb-nuclio-ingest)
   kind: string
-  description: "Injest function name. (e.g. default-tenant-tsdb-nuclio-ingest)"
+  description: "Injest function name"
   required: true
   attributes:
     defaultValue: default-tenant-tsdb-nuclio-ingest

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -1,4 +1,4 @@
-initialOffset:
+InitialOffset:
   displayName: Initial Offset
   kind: choice
   description: "Kafka initial offset"
@@ -7,26 +7,28 @@ initialOffset:
     choices: [Earliest, Latest]
     defaultValue: Latest
 
-consumerGroup:
+ConsumerGroup:
   displayName: Consumer group
   kind: string
   description: "Kafka consumer group name"
   required: false
 
-workerAllocatorName:
-  displayName: Worker allocator name
-  kind: string
-  description: "Kafka worker allocator name"
-  required: false
-
-topic:
+Topic:
   displayName: Topic
   kind: string
   description: "Kafka topic name"
   required: true
 
-broker:
+Broker:
   displayName: Broker
   kind: string
   description: "Kafka broker address"
   required: true
+
+InjestFunction:
+  displayName: InjestFunction
+  kind: string
+  description: "Injest function name. (e.g. default-tenant-tsdb-nuclio-ingest)"
+  required: true
+  attributes:
+    defaultValue: default-tenant-tsdb-nuclio-ingest

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -4,7 +4,7 @@ InitialOffset:
   description: "Kafka initial offset"
   required: true
   attributes:
-    choices: [Earliest, Latest]
+    choices: [earliest, latest]
     defaultValue: Latest
 
 ConsumerGroup:

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -25,10 +25,10 @@ Broker:
   description: "Kafka broker address"
   required: true
 
-InjestFunction:
-  displayName: Injest Function (e.g. default-tenant-tsdb-nuclio-ingest)
+IngestFunction:
+  displayName: Ingest Function (e.g. default-tenant-tsdb-nuclio-ingest)
   kind: string
-  description: "Injest function name"
+  description: "Ingest function name"
   required: true
   attributes:
     defaultValue: default-tenant-tsdb-nuclio-ingest

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -20,7 +20,7 @@ Topic:
   required: true
 
 Broker:
-  displayName: Broker
+  displayName: Kafka URL and port
   kind: string
   description: "Kafka broker address"
   required: true

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -5,7 +5,7 @@ InitialOffset:
   required: true
   attributes:
     choices: [earliest, latest]
-    defaultValue: Latest
+    defaultValue: latest
 
 ConsumerGroup:
   displayName: Consumer group

--- a/kafka-to-tsdb/function.yaml.values
+++ b/kafka-to-tsdb/function.yaml.values
@@ -1,0 +1,32 @@
+initialOffset:
+  displayName: Initial Offset
+  kind: choice
+  description: "Kafka initial offset"
+  required: true
+  attributes:
+    choices: [Earliest, Latest]
+    defaultValue: Latest
+
+consumerGroup:
+  displayName: Consumer group
+  kind: string
+  description: "Kafka consumer group name"
+  required: false
+
+workerAllocatorName:
+  displayName: Worker allocator name
+  kind: string
+  description: "Kafka worker allocator name"
+  required: false
+
+topic:
+  displayName: Topic
+  kind: string
+  description: "Kafka topic name"
+  required: true
+
+broker:
+  displayName: Broker
+  kind: string
+  description: "Kafka broker address"
+  required: true

--- a/kafka-to-tsdb/kafka-to-tsdb.py
+++ b/kafka-to-tsdb/kafka-to-tsdb.py
@@ -17,10 +17,10 @@ import json
 
 
 def handler(context, event):
-    injest_function = os.environ['INJEST_FUNCTION']
+    ingest_function = os.environ['INGEST_FUNCTION']
 
     # parse the given event body
     event_body = json.loads(event.body)
 
     # ingest the parsed event to tsdb
-    context.platform.call_function(injest_function, nuclio_sdk.Event(body=event_body))
+    context.platform.call_function(ingest_function, nuclio_sdk.Event(body=event_body))

--- a/kafka-to-tsdb/kafka-to-tsdb.py
+++ b/kafka-to-tsdb/kafka-to-tsdb.py
@@ -1,0 +1,25 @@
+# Copyright 2017 The Nuclio Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nuclio_sdk
+import json
+
+
+def handler(context, event):
+
+	# parse the given event body
+    event_body=json.loads(event.body)
+
+    # ingest the parsed event to tsdb
+    context.platform.call_function('default-tenant-tsdb-nuclio-ingest', nuclio_sdk.Event(body=event_body))

--- a/kafka-to-tsdb/kafka-to-tsdb.py
+++ b/kafka-to-tsdb/kafka-to-tsdb.py
@@ -17,9 +17,10 @@ import json
 
 
 def handler(context, event):
+    injest_function = os.environ['INJEST_FUNCTION']
 
-	# parse the given event body
-    event_body=json.loads(event.body)
+    # parse the given event body
+    event_body = json.loads(event.body)
 
     # ingest the parsed event to tsdb
-    context.platform.call_function('default-tenant-tsdb-nuclio-ingest', nuclio_sdk.Event(body=event_body))
+    context.platform.call_function(injest_function, nuclio_sdk.Event(body=event_body))

--- a/kafka-to-tsdb/kafka-to-tsdb.py
+++ b/kafka-to-tsdb/kafka-to-tsdb.py
@@ -15,12 +15,47 @@
 import nuclio_sdk
 import json
 
+INGEST_FUNCTION = os.environ['INGEST_FUNCTION']
+
+
+# Example tsdb event:
+#
+# {
+# 		"metric": "cpu",
+# 		"labels": {
+# 			"dc": "7",
+# 			"hostname": "mybesthost"
+# 		},
+# 		"samples": [
+# 			{
+# 				"t": "1532595945142",
+# 				"v": {
+# 					"N": 95.2
+# 				}
+# 			},
+# 			{
+# 				"t": "1532595948517",
+# 				"v": {
+# 					"n": 86.8
+# 				}
+# 			}
+# 		]
+# }
+
+
+# transform kafka event to tsdb event
+def transform_to_tsdb_event(event):
+
+    # implement the transformation
+    return event
+
 
 def handler(context, event):
-    ingest_function = os.environ['INGEST_FUNCTION']
 
     # parse the given event body
     event_body = json.loads(event.body)
 
+    tsdb_event = transform_to_tsdb_event(event_body)
+
     # ingest the parsed event to tsdb
-    context.platform.call_function(ingest_function, nuclio_sdk.Event(body=event_body))
+    context.platform.call_function(INGEST_FUNCTION, nuclio_sdk.Event(body=tsdb_event))


### PR DESCRIPTION
Listens on given kafka topic and ingests given events to TSDB
(Currently can only listen on 1 topic and 1 broker, until lists are supported)