### PR TITLE
Bump function templates to python 3.9

### DIFF
--- a/enrich-stream/function.yaml.template
+++ b/enrich-stream/function.yaml.template
@@ -7,7 +7,7 @@ spec:
     - pip install requests
   description: "Nuclio function which is triggered by incoming event-messages to a V3IO-Stream. The function enrich the original event-message with data from V3IO-KV table, and writes the enriched message to an output V3IO-Stream."
   handler: "main:handler"
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   env:
   - name: V3IO_API
     value: {{ .V3ioAPI }}

--- a/kafka-to-kv/function.yaml.template
+++ b/kafka-to-kv/function.yaml.template
@@ -7,7 +7,7 @@ spec:
     - pip install requests
   description: "Listens on given kafka topics and inserts given events to KV"
   handler: "main:handler"
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   env:
   - name: WEB_API_HOST_AND_PORT
     value: {{ .WebAPIHostAndPort }}

--- a/kafka-to-tsdb/function.yaml.template
+++ b/kafka-to-tsdb/function.yaml.template
@@ -5,7 +5,7 @@ spec:
     functionSourceCode: {{ .SourceCode }}
   description: "Listens on given kafka topics and ingests given events to TSDB"
   handler: "main:handler"
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   env:
   - name: INGEST_FUNCTION
     value: {{ .IngestFunction }}

--- a/mysql-to-kv-delta/function.yaml.template
+++ b/mysql-to-kv-delta/function.yaml.template
@@ -44,12 +44,12 @@ spec:
       value: {{ .SqlQueryCreatedDtCol }}
     - name: MODIFIED_DATETIME_COL
       value: {{ .SqlQueryModifiedDtCol }}
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   minReplicas: 1
   maxReplicas: 1
   build:
     functionSourceCode: {{ .SourceCode }}
     commands:
       - pip install v3io-frames sqlalchemy mysqlclient pandas
-    baseImage: "python:3.6"
+    baseImage: "python:3.9"
     

--- a/mysql-to-kv/function.yaml.template
+++ b/mysql-to-kv/function.yaml.template
@@ -39,11 +39,11 @@ spec:
       value: {{ .SqlDBName }}
     - name: SQL_QUERY
       value: {{ .SqlQuery }}
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   minReplicas: 1
   maxReplicas: 1
   build:
     functionSourceCode: {{ .SourceCode }}
     commands:
       - pip install v3io-frames sqlalchemy mysqlclient pandas
-    baseImage: "python:3.6"
+    baseImage: "python:3.9"

--- a/natural-lang/function.yaml.template
+++ b/natural-lang/function.yaml.template
@@ -8,7 +8,7 @@ spec:
   handler: "main:handler"
   maxReplicas: 1
   minReplicas: 1
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   build:
     commands:
       - 'pip install textblob'

--- a/string-manipulator/function.yaml.template
+++ b/string-manipulator/function.yaml.template
@@ -8,7 +8,7 @@ spec:
     - name: MANIPULATION_KIND
       value: {{ .ManipulationKind }}
   handler: "main:handler"
-  runtime: "python:3.6"
+  runtime: "python:3.9"
   minReplicas: 1
   maxReplicas: 1
   triggers:


### PR DESCRIPTION
Python 3.6 is deprecated from Nuclio.
https://jira.iguazeng.com/browse/NUC-100